### PR TITLE
feat: Support for private repos

### DIFF
--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -92,6 +92,7 @@ export class ReleaseArchive {
 }
 
 async function download(url: string, dest: string): Promise<void> {
+  const personalAccessToken = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
   if (process.env.INTEGRATION_TESTING) {
     // Point downloads to the standin github server
     // during integration testing.
@@ -118,6 +119,9 @@ async function download(url: string, dest: string): Promise<void> {
   try {
     response = await axios.get(url, {
       responseType: "stream",
+      headers: {
+        Authorization: `Bearer ${personalAccessToken}`,
+    },
     });
   } catch (e: any) {
     // https://axios-http.com/docs/handling_errors

--- a/src/infrastructure/git.ts
+++ b/src/infrastructure/git.ts
@@ -2,7 +2,12 @@ import { simpleGit } from "simple-git";
 
 export class GitClient {
   public async clone(url: string, repoPath: string): Promise<void> {
-    await simpleGit().clone(url, repoPath);
+    const personalAccessToken = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+    await simpleGit()
+    .env({ // Set environment variables for authentication
+        GIT_ASKPASS: "echo", // Disable credential prompt
+    })
+    .clone(url.replace('https://', `https://${personalAccessToken}@`), repoPath);
   }
 
   public async checkout(repoPath: string, ref?: string): Promise<void> {


### PR DESCRIPTION
Private Bazel modules can be published to cloned BCR repo. 
[Issue No. #1 ](https://github.com/machanirobotics/bazel-publish-bot/issues/1)